### PR TITLE
Fix URLs in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are a few config options for setting optional pre-length padding byte.  Re
 
 MIT
 
-Copyright 2014 Brian M. Carlson
+Copyright 2015 Brian M. Carlson
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianc/node-packet-parser.git"
+    "url": "git://github.com/brianc/node-packet-reader.git"
   },
   "author": "Brian M. Carlson",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/brianc/node-packet-parser/issues"
+    "url": "https://github.com/brianc/node-packet-reader/issues"
   },
-  "homepage": "https://github.com/brianc/node-packet-parser",
+  "homepage": "https://github.com/brianc/node-packet-reader",
   "devDependencies": {
     "mocha": "~1.16.2"
   }


### PR DESCRIPTION
I noticed the links on npm for this module were incorrect. They're linked to "node-packet-parser" (rather than "reader"): https://www.npmjs.com/package/packet-reader

This PR fixes that and also bumps up the (c) to 2015.
