### PR TITLE
Major performance improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var Reader = module.exports = function(options) {
   options = options || {}
   this.offset = 0
   this.lastChunk = false
-  this.chunk = null
+  this.chunk = Buffer.alloc(4);
+  this.chunkLength = 0;
   this.headerSize = options.headerSize || 0
   this.lengthPadding = options.lengthPadding || 0
   this.header = null
@@ -16,24 +17,39 @@ var Reader = module.exports = function(options) {
 }
 
 Reader.prototype.addChunk = function(chunk) {
-  this.offset = 0
-  this.chunk = chunk
-  if(this.lastChunk) {
-    this.chunk = Buffer.concat([this.lastChunk, this.chunk])
-    this.lastChunk = false
+  var newChunkLength = chunk.length;
+  var newLength = this.chunkLength + newChunkLength;
+
+  if (newLength > this.chunk.length) {
+    var newBufferLength = this.chunk.length * 2;
+    while (newLength >= newBufferLength) {
+      newBufferLength *= 2;
+    }
+    var newBuffer = new Buffer(newBufferLength);
+    this.chunk.copy(newBuffer);
+    this.chunk = newBuffer;
+  }
+  chunk.copy(this.chunk, this.chunkLength);
+  this.chunkLength = newLength;
+
+  // If more than half of the data has been read, shrink
+  // the buffer and reset the offset to reclaim the memory
+  var halfLength = this.chunk.length / 2;
+  if (this.offset > halfLength) {
+    var newBuffer = new Buffer(halfLength);
+    this.chunk.copy(newBuffer, 0, this.offset);
+    this.chunk = newBuffer;
+    this.chunkLength -= this.offset;
+    this.offset = 0;
   }
 }
 
 Reader.prototype._save = function() {
-  //save any unread chunks for next read
-  if(this.offset < this.chunk.length) {
-    this.lastChunk = this.chunk.slice(this.offset)
-  }
   return false
 }
 
 Reader.prototype.read = function() {
-  if(this.chunk.length < (this.headerSize + 4 + this.offset)) {
+  if(this.chunkLength < (this.headerSize + 4 + this.offset)) {
     return this._save()
   }
 
@@ -45,7 +61,7 @@ Reader.prototype.read = function() {
   var length = this.chunk.readUInt32BE(this.offset + this.headerSize) + this.lengthPadding
 
   //next item spans more chunks than we have
-  var remaining = this.chunk.length - (this.offset + 4 + this.headerSize)
+  var remaining = this.chunkLength - (this.offset + 4 + this.headerSize)
   if(length > remaining) {
     return this._save()
   }

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,20 @@ describe('packet-reader', function() {
     assert.equal(result.length, 16)
   })
 
+  it('compacts buffer when when more than half is read', function() {
+    this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
+    assert.equal(false, this.reader.read())
+    this.reader.addChunk(new Buffer([1, 2, 3, 4, 5, 6, 7, 8]))
+    assert.equal(false, this.reader.read())
+    this.reader.addChunk(new Buffer([9, 10, 11, 12, 13, 14, 15, 16]))
+    var result = this.reader.read()
+    assert.equal(result.length, 16)
+    assert.equal(this.reader.chunk.length, 32, 'should have doubled once 16 bytes were written')
+    this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
+    assert.equal(this.reader.offset, 0, 'should have been reset to 0.')
+    assert.equal(this.reader.chunk.length, 16, 'should have been cut in half')
+  })
+
   it('reads multiple messages from single chunk', function() {
     this.reader.addChunk(new Buffer([0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 1, 2]))
     var result = this.reader.read()

--- a/test/index.js
+++ b/test/index.js
@@ -41,18 +41,17 @@ describe('packet-reader', function() {
     assert.equal(result.length, 16)
   })
 
-  it('compacts buffer when when more than half is read', function() {
+  it('resets internal buffer at end of packet', function() {
     this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
-    assert.equal(false, this.reader.read())
     this.reader.addChunk(new Buffer([1, 2, 3, 4, 5, 6, 7, 8]))
-    assert.equal(false, this.reader.read())
     this.reader.addChunk(new Buffer([9, 10, 11, 12, 13, 14, 15, 16]))
     var result = this.reader.read()
     assert.equal(result.length, 16)
-    assert.equal(this.reader.chunk.length, 32, 'should have doubled once 16 bytes were written')
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
+
+    var newChunk = new Buffer([0, 0, 0, 0, 16])
+    this.reader.addChunk(newChunk)
     assert.equal(this.reader.offset, 0, 'should have been reset to 0.')
-    assert.equal(this.reader.chunk.length, 16, 'should have been cut in half')
+    assert.strictEqual(this.reader.chunk, newChunk)
   })
 
   it('reads multiple messages from single chunk', function() {


### PR DESCRIPTION
`Reader.prototype.addChunk` was calling `Buffer.concat` constantly, which increased garbage collection and just all-around killed performance. The exact implications of this is documented in https://github.com/brianc/node-postgres/issues/1286, which has a test case for showing how performance is affected.

Rather than concatenating buffers to the new buffer size constantly, this version uses a growth strategy that doubles the size of the buffer each time and tracks the functional length in a separate `chunkLength` variable. This significantly reduces the amount of allocation and provides a 25x
performance in my test cases, the larger the amount of data the query is returning, the greater improvement of performance.

Since this uses a doubling buffer, it was important to avoid unbounded growth, so I also added a reclamation strategy which reduces the size of the buffer by half whenever more than half of the data has been read.

I wasn't sure if it was okay to delete ` Reader.prototype._save` outright, since it now just always returns false in all cases.

I didn't add any new unit tests because the existing ones should cover the refactored code, but let me know if you would like me to add something specific.

Also, thanks for `node-postgres`, it's awesome and hopefully this helps makes it even more awesome. 😄 