### PR TITLE
Replace deprecated Buffer usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js: "6"
 matrix:
   include:
-    - node_js: "0.10"
-    - node_js: "0.12"
     - node_js: "4"
     - node_js: "5"
     - node_js: "6"

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ Reader.prototype.addChunk = function(chunk) {
     while (newLength >= newBufferLength) {
       newBufferLength *= 2
     }
-    var newBuffer = new Buffer(newBufferLength)
+    var newBuffer = Buffer.alloc(newBufferLength)
     this.chunk.copy(newBuffer)
     this.chunk = newBuffer
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/brianc/node-packet-reader",
   "devDependencies": {
-    "mocha": "~1.16.2"
+    "mocha": "~1.21.5"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ describe('packet-reader', function() {
   })
 
   it('reads perfect 1 length buffer', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 1, 1]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 1, 1]))
     var result = this.reader.read()
     assert.equal(result.length, 1)
     assert.equal(result[0], 1)
@@ -14,17 +14,17 @@ describe('packet-reader', function() {
   })
 
   it('reads perfect longer buffer', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 4, 1, 2, 3, 4]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 4, 1, 2, 3, 4]))
     var result = this.reader.read()
     assert.equal(result.length, 4)
     assert.strictEqual(false, this.reader.read())
   })
 
   it('reads two parts', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 1]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 1]))
     var result = this.reader.read()
     assert.strictEqual(false, result)
-    this.reader.addChunk(new Buffer([2]))
+    this.reader.addChunk(Buffer.from([2]))
     var result = this.reader.read()
     assert.equal(result.length, 1, 'should return 1 length buffer')
     assert.equal(result[0], 2)
@@ -32,30 +32,30 @@ describe('packet-reader', function() {
   })
 
   it('reads multi-part', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 16]))
     assert.equal(false, this.reader.read())
-    this.reader.addChunk(new Buffer([1, 2, 3, 4, 5, 6, 7, 8]))
+    this.reader.addChunk(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]))
     assert.equal(false, this.reader.read())
-    this.reader.addChunk(new Buffer([9, 10, 11, 12, 13, 14, 15, 16]))
+    this.reader.addChunk(Buffer.from([9, 10, 11, 12, 13, 14, 15, 16]))
     var result = this.reader.read()
     assert.equal(result.length, 16)
   })
 
   it('resets internal buffer at end of packet', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 16]))
-    this.reader.addChunk(new Buffer([1, 2, 3, 4, 5, 6, 7, 8]))
-    this.reader.addChunk(new Buffer([9, 10, 11, 12, 13, 14, 15, 16]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 16]))
+    this.reader.addChunk(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]))
+    this.reader.addChunk(Buffer.from([9, 10, 11, 12, 13, 14, 15, 16]))
     var result = this.reader.read()
     assert.equal(result.length, 16)
 
-    var newChunk = new Buffer([0, 0, 0, 0, 16])
+    var newChunk = Buffer.from([0, 0, 0, 0, 16])
     this.reader.addChunk(newChunk)
     assert.equal(this.reader.offset, 0, 'should have been reset to 0.')
     assert.strictEqual(this.reader.chunk, newChunk)
   })
 
   it('reads multiple messages from single chunk', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 1, 2]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 1, 2]))
     var result = this.reader.read()
     assert.equal(result.length, 1, 'should have 1 length buffer')
     assert.equal(result[0], 1)
@@ -67,14 +67,14 @@ describe('packet-reader', function() {
   })
 
   it('reads 1 and a split', function() {
-    this.reader.addChunk(new Buffer([0, 0, 0, 0, 1, 1, 0, 0]))//, 0, 0, 2, 1, 2]))
+    this.reader.addChunk(Buffer.from([0, 0, 0, 0, 1, 1, 0, 0]))//, 0, 0, 2, 1, 2]))
     var result = this.reader.read()
     assert.equal(result.length, 1, 'should have 1 length buffer')
     assert.equal(result[0], 1)
     var result = this.reader.read()
     assert.strictEqual(result, false)
 
-    this.reader.addChunk(new Buffer([0, 0, 2, 1, 2]))
+    this.reader.addChunk(Buffer.from([0, 0, 2, 1, 2]))
     var result = this.reader.read()
     assert.equal(result.length, 2, 'should have 2 length buffer but was ' + result.length)
     assert.equal(result[0], 1)
@@ -89,7 +89,7 @@ describe('variable length header', function() {
   })
 
   it('reads double message buffers', function() {
-    this.reader.addChunk(new Buffer([
+    this.reader.addChunk(Buffer.from([
                                 0, 0, 0, 1, 1,
                                 0, 0, 0, 2, 1, 2]))
     var result = this.reader.read()
@@ -111,7 +111,7 @@ describe('1 length code', function() {
   })
 
   it('reads code', function() {
-    this.reader.addChunk(new Buffer([9, 0, 0, 0, 1, 1]))
+    this.reader.addChunk(Buffer.from([9, 0, 0, 0, 1, 1]))
     var result = this.reader.read()
     assert(result)
     assert.equal(this.reader.header, 9)
@@ -121,7 +121,7 @@ describe('1 length code', function() {
 
   it('is set on uncompleted read', function() {
     assert.equal(this.reader.header, null)
-    this.reader.addChunk(new Buffer([2, 0, 0, 0, 1]))
+    this.reader.addChunk(Buffer.from([2, 0, 0, 0, 1]))
     assert.strictEqual(this.reader.read(), false)
     assert.equal(this.reader.header, 2)
   })
@@ -136,7 +136,7 @@ describe('postgres style packet', function() {
   })
 
   it('reads with padded length', function() {
-    this.reader.addChunk(new Buffer([1, 0, 0, 0, 8, 0, 0, 2, 0]))
+    this.reader.addChunk(Buffer.from([1, 0, 0, 0, 8, 0, 0, 2, 0]))
     var result = this.reader.read()
     assert(result)
     assert.equal(result.length, 4)


### PR DESCRIPTION
[The `Buffer` constructor is deprecated](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/). This change replaces all usages with the safe alternatives.