### PR TITLE
Don't publish test files and travis.yml to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   "homepage": "https://github.com/brianc/node-packet-reader",
   "devDependencies": {
     "mocha": "~1.21.5"
-  }
+  },
+  "files": []
 }


### PR DESCRIPTION
Just index.js and README.md will be published to reduce size.
Package size before optimization: 60kb
After landing this patch: 32kb